### PR TITLE
Fix "CUnixDynamicLoader error: ... /Bin/libEntitiesMP.so: undefined symbol: CGhostBusterRay_DLLClass"

### DIFF
--- a/Sources/Entities/PlayerWeapons.es
+++ b/Sources/Entities/PlayerWeapons.es
@@ -559,7 +559,7 @@ components:
   2 class   CLASS_BULLET            "Classes\\Bullet.ecl",
   3 class   CLASS_WEAPONEFFECT      "Classes\\PlayerWeaponsEffects.ecl",
   4 class   CLASS_PIPEBOMB          "Classes\\Pipebomb.ecl",
-  5 class   CLASS_GHOSTBUSTERRAY    "Classes\\GhostBusterRay.ecl",
+//  5 class   CLASS_GHOSTBUSTERRAY    "Classes\\GhostBusterRay.ecl",
   6 class   CLASS_CANNONBALL        "Classes\\CannonBall.ecl",
   7 class   CLASS_WEAPONITEM        "Classes\\WeaponItem.ecl",
 

--- a/Sources/EntitiesMP/PlayerWeapons.es
+++ b/Sources/EntitiesMP/PlayerWeapons.es
@@ -645,7 +645,7 @@ components:
   2 class   CLASS_BULLET            "Classes\\Bullet.ecl",
   3 class   CLASS_WEAPONEFFECT      "Classes\\PlayerWeaponsEffects.ecl",
   4 class   CLASS_PIPEBOMB          "Classes\\Pipebomb.ecl",
-  5 class   CLASS_GHOSTBUSTERRAY    "Classes\\GhostBusterRay.ecl",
+//  5 class   CLASS_GHOSTBUSTERRAY    "Classes\\GhostBusterRay.ecl",
   6 class   CLASS_CANNONBALL        "Classes\\CannonBall.ecl",
   7 class   CLASS_WEAPONITEM        "Classes\\WeaponItem.ecl",
   8 class   CLASS_BASIC_EFFECT      "Classes\\BasicEffect.ecl",


### PR DESCRIPTION
The error message did not go away after removing the unused source files. The real cause is this line and I verified it fixed the problem on TSE.

Was tricky to find because the string `CGhostBusterRay_DLLClass` doesn't actually appear in the final nor immediate binaries. Apparently some other logic in the loader knows to append `_DLLClass` for all entities.

Fixes #9