### PR TITLE
MCST Elbrus CPU support

### DIFF
--- a/Sources/Engine/Base/Types.h
+++ b/Sources/Engine/Base/Types.h
@@ -65,7 +65,7 @@ typedef uint32_t UINT;
 #endif
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__) || defined(_ARCH_PPC64) \
-    || defined(_M_IA64) || defined(__IA64__)
+    || defined(_M_IA64) || defined(__IA64__) || defined(__e2k__)
 
   #define PLATFORM_64BIT 1
 


### PR DESCRIPTION
Added initial support for MCST Elbrus CPU which has e2k architecture. This is VLIW/EPIC architecture like Intel Itanium CPU (IA-64).
The detection of the e2k CPU architecture has been added to the file:
- \Serious-Engine\Sources\Engine\Base\Types.h