### PR TITLE
Add SDL2 path for Ubuntu 18.04

### DIFF
--- a/Sources/cmake/FindSDL2.cmake
+++ b/Sources/cmake/FindSDL2.cmake
@@ -68,6 +68,7 @@
 SET(SDL2_SEARCH_PATHS
 	~/Library/Frameworks
 	/Library/Frameworks
+	/usr/include/x86_64-linux-gnu/SDL2
 	/usr/local
 	/usr
 	/sw # Fink


### PR DESCRIPTION
It couldn't find SDL2 on my system without this.