### PR TITLE
Fix GCC -Waddress warning in PlayCamera

### DIFF
--- a/Sources/Entities/Camera.es
+++ b/Sources/Entities/Camera.es
@@ -391,10 +391,8 @@ procedures:
   // determine camera type and jump to corresponding routine
   PlayCamera()
   {
-    // eventually add to movers list
-    CCameraMarker &cm = (CCameraMarker&)*m_penTarget;
     // if we have at least one marker
-    if( &cm!=NULL) {
+    if( m_penTarget!=NULL) {
       // treat camera as movable
       jump PlayMovingCamera();
     // if there isn't any markers


### PR DESCRIPTION
GCC 11 says:

```
Sources/Entities/Camera.es:397:10: warning: the compiler can assume that the address of ‘cm’ will never be NULL [-Waddress]
```

The MP version of `Camera.es` simply checks `m_penTarget` instead, so that's what I've done here. It's not clear what the intention of the original code was.

P.S. I've got many more changes on the way. :smile: 