### PR TITLE
Check for AppleClang

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 ## ** RAKE! clean up for SeriousEngine use. Also  **
 ## ** RAKE! need to make this pandora safe.	  **
 # compiler specific flags
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
 	# This section and the like are for flags/defines that can be shared between 
 	# c and c++ compile options
 	add_compile_options(-Wall)


### PR DESCRIPTION
The default CMAKE_C_COMPILER_ID on macOS is AppleClang.
Clang is not recognised, and therefore the script fails with "Unsupported compiler".