### PR TITLE
Fix sniper FOV bug

### DIFF
--- a/Sources/EntitiesMP/Player.es
+++ b/Sources/EntitiesMP/Player.es
@@ -2397,7 +2397,7 @@ functions:
       aFOV = 90.0f;
     }
     // if sniper active
-    if (((CPlayerWeapons&)*m_penWeapons).m_iCurrentWeapon==WEAPON_SNIPER)
+    if (((CPlayerWeapons&)*m_penWeapons).m_iCurrentWeapon==WEAPON_SNIPER && ((CPlayerWeapons&)*m_penWeapons).m_bSniping)
     {
       aFOV = Lerp(((CPlayerWeapons&)*m_penWeapons).m_fSniperFOVlast,
                   ((CPlayerWeapons&)*m_penWeapons).m_fSniperFOV,


### PR DESCRIPTION
This game will incorrectly use the FOV calculated for the scope whenever the sniper is selected. The Sniper scope FOV starts from 90 so this is only visible when changing the FOV and is very annoying.