### PR TITLE
Pause the game when the window is minimized

### DIFF
--- a/Sources/Engine/Base/SDL/SDLEvents.cpp
+++ b/Sources/Engine/Base/SDL/SDLEvents.cpp
@@ -85,6 +85,11 @@ BOOL PeekMessage(MSG *msg, void *hwnd, UINT wMsgFilterMin,
                     msg->message = WM_PAINT;
                     return TRUE;
                 }
+                if (sdlevent.window.event == SDL_WINDOWEVENT_MINIMIZED)
+                {
+                    msg->wParam = sdlevent.window.event;
+                    return TRUE;
+                }
                 break;
 
             // These all map to WM_* things without any drama.

--- a/Sources/SeriousSam/SeriousSam.cpp
+++ b/Sources/SeriousSam/SeriousSam.cpp
@@ -1028,7 +1028,21 @@ int SubMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int 
         }
       }
 #else
-      STUBBED("SDL2 can handle these events");
+      if( msg.message==SDL_WINDOWEVENT)
+      {
+        switch( msg.wParam) {
+        case SDL_WINDOWEVENT_MINIMIZED:
+          if( _bWindowChanging) break;
+          _bWindowChanging  = TRUE;
+          _bReconsiderInput = TRUE;
+          // if allowed, not already paused and only in single player game mode
+          if( sam_bPauseOnMinimize && !_pNetwork->IsPaused() && _gmRunningGameMode==GM_SINGLE_PLAYER) {
+            // pause game
+            _pNetwork->TogglePause();
+          }
+          break;
+        }
+      }
 #endif
 
       // toggle full-screen on alt-enter


### PR DESCRIPTION
it only handle SDL_WINDOWEVENT_MINIMIZED for now, but looking at the win32 code just a few line upper we could handle other events if needed (SDL_WINDOWEVENT_MAXIMIZED, SDL_WINDOWEVENT_LEAVE, SDL_WINDOWEVENT_ENTER, ...)