### PR TITLE
don't segfault when hidding the splashscreen

### DIFF
--- a/Sources/SeriousSam/SplashScreen.cpp
+++ b/Sources/SeriousSam/SplashScreen.cpp
@@ -131,9 +131,9 @@ static SDL_Texture *texture = NULL;
 
 void HideSplashScreen(void)
 {
+  if (window) { SDL_DestroyWindow(window); window = NULL; }
   if (texture) { SDL_DestroyTexture(texture); texture = NULL; }
   if (renderer) { SDL_DestroyRenderer(renderer); renderer = NULL; }
-  if (window) { SDL_DestroyWindow(window); window = NULL; }
 }
 
 void ShowSplashScreen(HINSTANCE hInstance)


### PR DESCRIPTION
the entire SplashScreen concept is a bit outdated & mostly unused here (you have to copy a "splash.bmp" file in the currentdir to trigger that codepath) but a segfault is Bad