### PR TITLE
Fix undefined behavior in texture effects

### DIFF
--- a/Sources/Engine/Graphics/TextureEffects.cpp
+++ b/Sources/Engine/Graphics/TextureEffects.cpp
@@ -1250,7 +1250,7 @@ static void AnimateWater( SLONG slDensity)
 //////////////////////////// displace texture
 
 
-#define PIXEL(u,v) pulTextureBase[ ((u)&(SLONG&)mmBaseWidthMask) + ((v)&(SLONG&)mmBaseHeightMask) *pixBaseWidth]
+#define PIXEL(u,v) pulTextureBase[ ((ULONG)(u)&mmBaseWidthMask) + (((ULONG)(v)&mmBaseHeightMask) *pixBaseWidth)]
 
 ULONG _slHeightMapStep_renderWater = 0;
 PIX _pixBaseWidth_renderWater = 0;


### PR DESCRIPTION
The original cast only made the masks signed long which didn't work as expected on all platforms. Casting everything to unsigned long seems to be more consistent. The signed version resulted in the animated texture layer to be missing on the Lava Golem's body among other things.