### PR TITLE
Misc SDL fixes

### DIFF
--- a/Sources/Engine/Graphics/GfxLibrary.cpp
+++ b/Sources/Engine/Graphics/GfxLibrary.cpp
@@ -86,7 +86,7 @@ extern BOOL CVA_bModels;
 static FLOAT _fLastBrightness, _fLastContrast, _fLastGamma;
 static FLOAT _fLastBiasR, _fLastBiasG, _fLastBiasB;
 static INDEX _iLastLevels;
-#ifdef PLATFORM_WIN32 // DG: not used on other platforms
+#ifndef PLATFORM_PANDORA // DG: not used on other platforms
 static UWORD _auwGammaTable[256*3];
 #endif
 
@@ -1799,7 +1799,7 @@ INDEX _ctProbeShdU = 0;
 INDEX _ctProbeShdB = 0;
 INDEX _ctFullShdU  = 0;
 SLONG _slFullShdUBytes = 0;
-#ifdef PLATFORM_WIN32 // only used there
+#ifndef PLATFORM_PANDORA // only used there
 static BOOL GenerateGammaTable(void);
 #endif
 
@@ -2003,6 +2003,18 @@ void CGfxLibrary::SwapBuffers(CViewPort *pvp)
     }
   } 
   else
+#else
+  if( gl_ulFlags & GLF_ADJUSTABLEGAMMA) {
+    // ... and required
+    const BOOL bTableSet = GenerateGammaTable();
+    if( bTableSet) {
+        Uint16 *rampR = &_auwGammaTable[0];
+        Uint16 *rampG = &_auwGammaTable[256];
+        Uint16 *rampB = &_auwGammaTable[512];
+        SDL_SetWindowGammaRamp((SDL_Window *) pvp->vp_hWnd, rampR, rampG, rampB);
+    }
+  }
+  else
 #endif
   // if not supported
   {
@@ -2063,7 +2075,7 @@ void CGfxLibrary::UnlockRaster( CRaster *praToUnlock)
 }
 
 
-#ifdef PLATFORM_WIN32 // DG: only used on windows
+#ifndef PLATFORM_PANDORA // DG: only used on windows
 // generates gamma table and returns true if gamma table has been changed
 static BOOL GenerateGammaTable(void)
 {

--- a/Sources/SeriousSam/SeriousSam.cpp
+++ b/Sources/SeriousSam/SeriousSam.cpp
@@ -696,7 +696,9 @@ void End(void)
     pdpNormal   = NULL;
   }
 
+#ifdef PLATFORM_WIN32
   CloseMainWindow();
+#endif
   MainWindow_End();
   DestroyMenus();
   _pGame->End();
@@ -704,6 +706,9 @@ void End(void)
   // unlock the directory
   DirectoryLockOff();
   SE_EndEngine();
+#ifndef PLATFORM_WIN32
+  CloseMainWindow();
+#endif
 
 #if PLATFORM_UNIX
   SDL_Quit();


### PR DESCRIPTION
This PR adds gamma correction support for SDL2, and moves the final CloseMainWindow after SE_EndEngine. Since closing the SDL window can destroy the OpenGL context too, it's safer to do it when there can be no more OpenGL function calls at exit.